### PR TITLE
Update dockerfiles (fixes public key repo error and docker-compose.yaml)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ ENV PATH=$PATH:/project/sawtooth-sdk-java/bin
 
 WORKDIR /
 
-CMD /project/sawtooth-sdk-java/bin/build_java_sdk \
- && /project/sawtooth-sdk-java/bin/build_java_intkey \
+RUN mkdir /build
+
+COPY . /build/
+
+RUN /build/bin/build_java_sdk
+
+CMD /project/sawtooth-sdk-java/bin/build_java_intkey \
  && /project/sawtooth-sdk-java/bin/build_java_xo

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,13 @@ node ('master') {
         env.ISOLATION_ID = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
         env.COMPOSE_PROJECT_NAME = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
 
+        // Build the test dependencies
+        stage("Build test dependencies") {
+            sh 'docker-compose -f docker/compose/java-build.yaml build'
+            sh 'docker-compose -f docker/compose/java-build.yaml up'
+            sh 'docker-compose -f docker/compose/java-build.yaml down'
+        }
+
         // Run the tests
         stage("Run Tests") {
             sh 'docker-compose -f examples/intkey_java/tests/test_intkey_smoke_java.yaml up --abort-on-container-exit'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ node ('master') {
 
         // Set the ISOLATION_ID environment variable for the whole pipeline
         env.ISOLATION_ID = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
+        env.COMPOSE_PROJECT_NAME = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
 
         // Run the tests
         stage("Run Tests") {

--- a/docker/compose/java-build.yaml
+++ b/docker/compose/java-build.yaml
@@ -1,0 +1,42 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  intkey-tp-java:
+    build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+      context: ../..
+      dockerfile: ./examples/intkey_java/Dockerfile
+    image: sawtooth-intkey-tp-java-local:$ISOLATION_ID
+    volumes:
+      - ../..:/project/sawtooth-sdk-java
+
+  xo-tp-java:
+    build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+      context: ../..
+      dockerfile: ./examples/xo_java/Dockerfile
+    image: sawtooth-xo-tp-java-local:$ISOLATION_ID
+    volumes:
+      - ../..:/project/sawtooth-sdk-java

--- a/examples/intkey_java/Dockerfile
+++ b/examples/intkey_java/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2018 Bitwise IO
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM maven:3-jdk-8
+
+LABEL "install-type"="mounted"
+
+EXPOSE 4004/tcp
+
+RUN mkdir -p /project/sawtooth-sdk-java/ \
+ && mkdir -p /var/log/sawtooth \
+ && mkdir -p /var/lib/sawtooth \
+ && mkdir -p /etc/sawtooth \
+ && mkdir -p /etc/sawtooth/keys
+
+ENV PATH=$PATH:/project/sawtooth-sdk-java/bin
+
+WORKDIR /
+
+RUN mkdir /build
+
+COPY . /build/
+
+RUN /build/bin/build_java_sdk
+
+CMD /project/sawtooth-sdk-java/bin/build_java_intkey

--- a/examples/intkey_java/intkey-tests.dockerfile
+++ b/examples/intkey_java/intkey-tests.dockerfile
@@ -16,7 +16,8 @@
 FROM ubuntu:xenial
 
 RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update
 
 RUN apt-get install -y -q \

--- a/examples/intkey_java/tests/test_intkey_smoke_java.yaml
+++ b/examples/intkey_java/tests/test_intkey_smoke_java.yaml
@@ -28,8 +28,12 @@ services:
 
   intkey-tp-java:
     build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
       context: ../../..
-      dockerfile: ./Dockerfile
+      dockerfile: ./examples/intkey_java/Dockerfile
     image: sawtooth-intkey-tp-java-local:$ISOLATION_ID
     volumes:
       - ../../..:/project/sawtooth-sdk-java

--- a/examples/intkey_java/tests/test_tp_intkey_java.yaml
+++ b/examples/intkey_java/tests/test_tp_intkey_java.yaml
@@ -40,7 +40,7 @@ services:
       - 4004
     command: nose2-3
         -v
-        -s /tmp/tests/intkey/
+        -s /data/tests/intkey/
         test_tp_intkey
     stop_signal: SIGKILL
     environment:

--- a/examples/intkey_java/tests/test_tp_intkey_java.yaml
+++ b/examples/intkey_java/tests/test_tp_intkey_java.yaml
@@ -19,8 +19,12 @@ services:
 
   intkey-tp-java:
     build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
       context: ../../..
-      dockerfile: ./Dockerfile
+      dockerfile: ./examples/intkey_java/Dockerfile
     image: sawtooth-intkey-tp-java-local:$ISOLATION_ID
     volumes:
       - ../../..:/project/sawtooth-sdk-java

--- a/examples/xo_java/Dockerfile
+++ b/examples/xo_java/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright 2018 Bitwise IO
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,18 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-
-# Description:
-#   Builds an image to be used when developing in Java. The default CMD is to run
-#   build_java.
-#
-# Build:
-#   $ cd sawtooth-sdk-java
-#   $ docker build . -t sawtooth-sdk-java
-#
-# Run:
-#   $ cd sawtooth-sdk-java
-#   $ docker run -v $(pwd):/project/sawtooth-sdk-java sawtooth-sdk-java
 
 FROM maven:3-jdk-8
 
@@ -47,5 +35,4 @@ COPY . /build/
 
 RUN /build/bin/build_java_sdk
 
-CMD /project/sawtooth-sdk-java/bin/build_java_intkey \
- && /project/sawtooth-sdk-java/bin/build_java_xo
+CMD /project/sawtooth-sdk-java/bin/build_java_xo

--- a/examples/xo_java/tests/test_tp_xo_java.yaml
+++ b/examples/xo_java/tests/test_tp_xo_java.yaml
@@ -19,8 +19,12 @@ services:
 
   xo-tp-java:
     build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
       context: ../../..
-      dockerfile: ./Dockerfile
+      dockerfile: ./examples/xo_java/Dockerfile
     image: sawtooth-xo-tp-java-local:$ISOLATION_ID
     volumes:
       - ../../..:/project/sawtooth-sdk-java

--- a/examples/xo_java/tests/test_tp_xo_java.yaml
+++ b/examples/xo_java/tests/test_tp_xo_java.yaml
@@ -40,7 +40,7 @@ services:
       - 4004
     command: nose2-3
         -v
-        -s /tmp/tests/xo
+        -s /data/tests/xo
         test_tp_xo
     stop_signal: SIGKILL
     environment:

--- a/examples/xo_java/tests/test_xo_smoke_java.yaml
+++ b/examples/xo_java/tests/test_xo_smoke_java.yaml
@@ -28,8 +28,12 @@ services:
 
   xo-tp-java:
     build:
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
       context: ../../..
-      dockerfile: ./Dockerfile
+      dockerfile: ./examples/xo_java/Dockerfile
     image: sawtooth-xo-tp-java-local:$ISOLATION_ID
     volumes:
       - ../../..:/project/sawtooth-sdk-java

--- a/examples/xo_java/xo-tests.dockerfile
+++ b/examples/xo_java/xo-tests.dockerfile
@@ -16,7 +16,8 @@
 FROM ubuntu:xenial
 
 RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
  && apt-get update
 
 RUN apt-get install -y -q \


### PR DESCRIPTION
This fixes the public key error in accessing the sawtooth apt repo for python test dependencies and provides a single docker-compose.yaml entry point.