### PR TITLE
Add jdk8 profile for jdk8 jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,35 @@
 
             </build>
         </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <finalName>${project.artifactId}-jdk8</finalName>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <classifier>jdk8</classifier>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven.compiler.plugin.version}</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <testSource>1.8</testSource>
+                            <testTarget>1.8</testTarget>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 


### PR DESCRIPTION
The jdk8 jars are needed for Android.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>