### PR TITLE
Update smoke test docker-compose.yaml to include devmode engine

### DIFF
--- a/examples/intkey_java/tests/test_intkey_smoke_java.yaml
+++ b/examples/intkey_java/tests/test_intkey_smoke_java.yaml
@@ -48,6 +48,7 @@ services:
     image: hyperledger/sawtooth-validator
     expose:
       - 4004
+      - 5050
     command: "bash -c \"\
         sawadm keygen && \
         sawset genesis \
@@ -58,6 +59,7 @@ services:
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5050 \
     \""
     stop_signal: SIGKILL
 
@@ -87,4 +89,14 @@ services:
         -v
         -s /usr/lib/python3/dist-packages/sawtooth_integration/tests/
         test_intkey_smoke.TestIntkeySmoke
+    stop_signal: SIGKILL
+
+  devmode-rust:
+    image: hyperledger/sawtooth-devmode-engine-rust
+    depends_on:
+      - validator
+    command: |
+      bash -c "
+        devmode-engine-rust -v --connect tcp://validator:5050
+      "
     stop_signal: SIGKILL

--- a/examples/xo_java/tests/test_xo_smoke_java.yaml
+++ b/examples/xo_java/tests/test_xo_smoke_java.yaml
@@ -48,7 +48,7 @@ services:
     image: hyperledger/sawtooth-validator
     expose:
       - 4004
-      - 8800
+      - 5050
     command: "bash -c \"\
         sawadm keygen && \
         sawset genesis \
@@ -58,6 +58,7 @@ services:
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5050 \
     \""
     stop_signal: SIGKILL
 
@@ -88,4 +89,14 @@ services:
         -v
         -s /usr/lib/python3/dist-packages/sawtooth_integration/tests/
         test_xo_smoke.TestXoSmoke
+    stop_signal: SIGKILL
+
+  devmode-rust:
+    image: hyperledger/sawtooth-devmode-engine-rust
+    depends_on:
+      - validator
+    command: |
+      bash -c "
+        devmode-engine-rust -v --connect tcp://validator:5050
+      "
     stop_signal: SIGKILL


### PR DESCRIPTION
Smoke tests are failling as the validator image being pulled
from docker hub is version 1.1 and it needs a consensus engine.
This commit adds the devmode engine to the network to fix this issue.

Signed-off-by: Eloá França Verona <eloafran@bitwise.io>