### PR TITLE
 Add deleteState, addReceiptData, and addEvent methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,4 +191,20 @@
     </profiles>
 
 
+    <dependencyManagement>
+     <dependencies>
+      <dependency>
+       <groupId>junit</groupId>
+       <artifactId>junit</artifactId>
+       <version>4.12</version>
+       <scope>test</scope>
+      </dependency>
+      <dependency>
+       <groupId>org.mockito</groupId>
+       <artifactId>mockito-core</artifactId>
+       <version>2.27.0</version>
+       <scope>test</scope>
+      </dependency>
+     </dependencies>
+    </dependencyManagement>
 </project>

--- a/sawtooth-sdk-transaction-processor/pom.xml
+++ b/sawtooth-sdk-transaction-processor/pom.xml
@@ -61,6 +61,14 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
     
     <build>

--- a/sawtooth-sdk-transaction-processor/pom.xml
+++ b/sawtooth-sdk-transaction-processor/pom.xml
@@ -62,4 +62,31 @@
             <version>2.3.1</version>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <configLocation>${checkstyle.path}</configLocation>
+                            <consoleOutput>true</consoleOutput>
+                            <failOnViolation>true</failOnViolation>
+                            <violationSeverity>warning</violationSeverity>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/ZmqStream.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/ZmqStream.java
@@ -1,0 +1,156 @@
+/* Copyright 2016,  2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package sawtooth.sdk.messaging;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.google.protobuf.ByteString;
+
+import sawtooth.sdk.protobuf.Message;
+
+/**
+ * A ZMQ implementation of client networking class.
+ */
+public class ZmqStream implements Stream {
+  /**
+   * Futures that are waiting to be resolved.
+   */
+  private ConcurrentHashMap<String, Future> futureHashMap;
+  /**
+   * Threadsafe queue to interact with the background thread.
+   */
+  private LinkedBlockingQueue<SendReceiveThread.MessageWrapper> receiveQueue;
+  /**
+   * The background thread.
+   */
+  private SendReceiveThread sendReceiveThread;
+  /**
+   * The Thread that drives the background sendReceiveThread.
+   */
+  private Thread thread;
+
+  /**
+   * The constructor.
+   * @param address the zmq address.
+   */
+  public ZmqStream(final String address) {
+    this.futureHashMap = new ConcurrentHashMap<String, Future>();
+    this.receiveQueue = new LinkedBlockingQueue<SendReceiveThread.MessageWrapper>();
+    this.sendReceiveThread = new SendReceiveThread(address, futureHashMap, this.receiveQueue);
+    this.thread = new Thread(sendReceiveThread);
+    this.thread.start();
+  }
+
+  /**
+   * Send a message and return a Future that will later have the Bytestring.
+   * @param destination one of the Message.MessageType enum values defined in
+   *                    validator.proto
+   * @param contents    the ByteString that has been serialized from a Protobuf
+   *                    class
+   * @return future a future that will have ByteString that can be deserialized
+   *         into a, for example, GetResponse
+   */
+  @Override
+  public final Future send(final Message.MessageType destination, final ByteString contents) {
+
+    Message message = Message.newBuilder().setCorrelationId(this.generateId()).setMessageType(destination)
+        .setContent(contents).build();
+
+    FutureByteString future = new FutureByteString(message.getCorrelationId());
+    this.futureHashMap.put(message.getCorrelationId(), future);
+    this.sendReceiveThread.sendMessage(message);
+    return future;
+  }
+
+  /**
+   * Send a message without getting a future back. Useful for sending a response
+   * message to, for example, a transaction
+   * @param destination   Message.MessageType defined in validator.proto
+   * @param correlationId a random string generated on the server for the client
+   *                      to send back
+   * @param contents      ByteString serialized contents that the server is
+   *                      expecting
+   */
+  @Override
+  public final void sendBack(final Message.MessageType destination, final String correlationId,
+      final ByteString contents) {
+    Message message = Message.newBuilder().setCorrelationId(correlationId).setMessageType(destination)
+        .setContent(contents).build();
+
+    this.sendReceiveThread.sendMessage(message);
+  }
+
+  /**
+   * close the Stream.
+   */
+  @Override
+  public final void close() {
+    try {
+      this.sendReceiveThread.stop();
+      this.thread.join();
+    } catch (InterruptedException ie) {
+      ie.printStackTrace();
+    }
+  }
+
+  /**
+   * Get a message that has been received.
+   * @return result, a protobuf Message
+   */
+  @Override
+  public final Message receive() {
+    SendReceiveThread.MessageWrapper result = null;
+    try {
+      result = this.receiveQueue.take();
+    } catch (InterruptedException ie) {
+      ie.printStackTrace();
+    }
+    return result.getMessage();
+  }
+
+  /**
+   * Get a message that has been received. If the timeout is expired, throws
+   * TimeoutException.
+   * @param timeout time to wait for a message.
+   * @return result, a protobuf Message
+   * @throws TimeoutException The Message is not received before timeout.
+   */
+  @Override
+  public final Message receive(final long timeout) throws TimeoutException {
+    SendReceiveThread.MessageWrapper result = null;
+    try {
+      result = this.receiveQueue.poll(timeout, TimeUnit.SECONDS);
+      if (result == null) {
+        throw new TimeoutException("The recieve queue timed out.");
+      }
+    } catch (InterruptedException ie) {
+      ie.printStackTrace();
+    }
+    return result.getMessage();
+  }
+
+  /**
+   * generate a random String, to correlate sent messages. with futures
+   * @return a random String
+   */
+  private String generateId() {
+    return UUID.randomUUID().toString();
+  }
+
+}

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/Context.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/Context.java
@@ -28,7 +28,6 @@ public interface Context {
 
   /**
    * Make a Get request on a specific context specified by contextId.
-   *
    * @param addresses a collection of address Strings
    * @return Map where the keys are addresses, values Bytestring
    * @throws InternalError               something went wrong processing
@@ -39,7 +38,6 @@ public interface Context {
 
   /**
    * Make a Set request on a specific context specified by contextId.
-   *
    * @param addressValuePairs A collection of Map.Entry's
    * @return addressesThatWereSet, A collection of address Strings that were set
    * @throws InternalError               something went wrong processing
@@ -49,5 +47,35 @@ public interface Context {
   Collection<String> setState(Collection<java.util.Map.Entry<String, ByteString>> addressValuePairs)
       throws InternalError, InvalidTransactionException;
 
-}
+  /**
+   * Make a Delete request on a specific context specified by contextId.
+   * @param addresses a collection of address Strings
+   * @return addressesThatWereDeleted, A collection of address Strings that were
+   *         deleted
+   * @throws InternalError               something went wrong processing
+   *                                     transaction
+   * @throws InvalidTransactionException an invalid transaction was encountered
+   */
+  Collection<String> deleteState(Collection<String> addresses) throws InternalError, InvalidTransactionException;
 
+  /**
+   * Add a blob to the execution result for this transaction.
+   * @param data The data to add
+   * @throws InternalError something went wrong processing transaction
+   */
+  void addReceiptData(ByteString data) throws InternalError;
+
+  /**
+   * Adds a new event to the execution result for this transaction.
+   * @param eventType  This is used to subscribe to events. It should be globally
+   *                   unique and describe what, in general, has occurred.
+   * @param attributes Additional information about the event that is transparent
+   *                   to the validator. Attributes can be used by subscribers to
+   *                   filter the type of events they receive.
+   * @param data       Additional information about the event that is opaque to
+   *                   the validator, or null
+   * @throws InternalError something went wrong processing transaction
+   */
+  void addEvent(String eventType, Collection<Map.Entry<String, String>> attributes, ByteString data)
+      throws InternalError;
+}

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/StreamContext.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/StreamContext.java
@@ -49,7 +49,7 @@ import sawtooth.sdk.protobuf.TpStateSetResponse;
  * Client state that interacts with the context manager through Stream
  * networking.
  */
-public class ZmqContext implements Context {
+public class StreamContext implements Context {
 
   /**
    * The stream networking for this class.
@@ -71,7 +71,7 @@ public class ZmqContext implements Context {
    * @param myStream    a networking stream
    * @param myContextId a context id
    */
-  public ZmqContext(final Stream myStream, final String myContextId) {
+  public StreamContext(final Stream myStream, final String myContextId) {
     this.stream = myStream;
     this.contextId = myContextId;
   }

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/StreamContext.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/StreamContext.java
@@ -112,9 +112,6 @@ public class StreamContext implements Context {
         results.put(entry.getAddress(), entry.getData());
       }
     }
-    if (results.isEmpty()) {
-      throw new InternalError("State Error, no result found for get request:" + addresses.toString());
-    }
 
     return results;
   }
@@ -193,9 +190,6 @@ public class StreamContext implements Context {
       for (String entry : delResponse.getAddressesList()) {
         results.add(entry);
       }
-    }
-    if (results.isEmpty()) {
-      throw new InternalError("State Error, no addresses found for delete request:" + addresses.toString());
     }
 
     return results;

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -19,6 +19,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 
 import sawtooth.sdk.messaging.Future;
 import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.messaging.ZmqStream;
 import sawtooth.sdk.processor.exceptions.InternalError;
 import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
 import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
@@ -97,7 +98,7 @@ public class TransactionProcessor implements Runnable {
    * @param address the zmq address
    */
   public TransactionProcessor(final String address) {
-    this.stream = new Stream(address);
+    this.stream = new ZmqStream(address);
     this.handlers = new ArrayList<TransactionHandler>();
     this.currentMessage = null;
     this.registered = false;
@@ -150,7 +151,7 @@ public class TransactionProcessor implements Runnable {
       final Message message, final Stream stream, final TransactionHandler handler) {
     try {
       TpProcessRequest transactionRequest = TpProcessRequest.parseFrom(message.getContent());
-      Context state = new ZmqContext(stream, transactionRequest.getContextId());
+      Context state = new StreamContext(stream, transactionRequest.getContextId());
 
       TpProcessResponse.Builder builder = TpProcessResponse.newBuilder();
       try {

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/ZmqContext.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/ZmqContext.java
@@ -14,6 +14,13 @@
 
 package sawtooth.sdk.processor;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -22,17 +29,21 @@ import sawtooth.sdk.messaging.Stream;
 import sawtooth.sdk.processor.exceptions.InternalError;
 import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
 import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+import sawtooth.sdk.protobuf.Event;
+import sawtooth.sdk.protobuf.Event.Attribute;
+import sawtooth.sdk.protobuf.Event.Builder;
 import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.TpEventAddRequest;
+import sawtooth.sdk.protobuf.TpEventAddResponse;
+import sawtooth.sdk.protobuf.TpReceiptAddDataRequest;
+import sawtooth.sdk.protobuf.TpReceiptAddDataResponse;
+import sawtooth.sdk.protobuf.TpStateDeleteRequest;
+import sawtooth.sdk.protobuf.TpStateDeleteResponse;
 import sawtooth.sdk.protobuf.TpStateEntry;
 import sawtooth.sdk.protobuf.TpStateGetRequest;
 import sawtooth.sdk.protobuf.TpStateGetResponse;
 import sawtooth.sdk.protobuf.TpStateSetRequest;
 import sawtooth.sdk.protobuf.TpStateSetResponse;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Client state that interacts with the context manager through Stream
@@ -57,7 +68,6 @@ public class ZmqContext implements Context {
 
   /**
    * The constructor for this class.
-   * 
    * @param myStream    a networking stream
    * @param myContextId a context id
    */
@@ -68,7 +78,6 @@ public class ZmqContext implements Context {
 
   /**
    * Make a Get request on a specific context specified by contextId.
-   *
    * @param addresses a collection of address Strings
    * @return Map where the keys are addresses, values Bytestring
    * @throws InternalError               something went wrong processing
@@ -79,7 +88,7 @@ public class ZmqContext implements Context {
   public final Map<String, ByteString> getState(final Collection<String> addresses)
       throws InternalError, InvalidTransactionException {
     TpStateGetRequest getRequest = TpStateGetRequest.newBuilder().addAllAddresses(addresses)
-  .setContextId(this.contextId).build();
+        .setContextId(this.contextId).build();
     Future future = stream.send(Message.MessageType.TP_STATE_GET_REQUEST, getRequest.toByteString());
     TpStateGetResponse getResponse = null;
     try {
@@ -97,10 +106,10 @@ public class ZmqContext implements Context {
     Map<String, ByteString> results = new HashMap<String, ByteString>();
     if (getResponse != null) {
       if (getResponse.getStatus() == TpStateGetResponse.Status.AUTHORIZATION_ERROR) {
-  throw new InvalidTransactionException("Tried to get unauthorized address " + addresses.toString());
+        throw new InvalidTransactionException("Tried to get unauthorized address " + addresses.toString());
       }
       for (TpStateEntry entry : getResponse.getEntriesList()) {
-  results.put(entry.getAddress(), entry.getData());
+        results.put(entry.getAddress(), entry.getData());
       }
     }
     if (results.isEmpty()) {
@@ -112,7 +121,6 @@ public class ZmqContext implements Context {
 
   /**
    * Make a Set request on a specific context specified by contextId.
-   *
    * @param addressValuePairs A collection of Map.Entry's
    * @return addressesThatWereSet, A collection of address Strings that were set
    * @throws InternalError               something went wrong processing
@@ -125,11 +133,11 @@ public class ZmqContext implements Context {
     ArrayList<TpStateEntry> entryArrayList = new ArrayList<TpStateEntry>();
     for (Map.Entry<String, ByteString> entry : addressValuePairs) {
       TpStateEntry ourTpStateEntry = TpStateEntry.newBuilder().setAddress(entry.getKey()).setData(entry.getValue())
-    .build();
+          .build();
       entryArrayList.add(ourTpStateEntry);
     }
     TpStateSetRequest setRequest = TpStateSetRequest.newBuilder().addAllEntries(entryArrayList)
-  .setContextId(this.contextId).build();
+        .setContextId(this.contextId).build();
     Future future = stream.send(Message.MessageType.TP_STATE_SET_REQUEST, setRequest.toByteString());
     TpStateSetResponse setResponse = null;
     try {
@@ -148,14 +156,110 @@ public class ZmqContext implements Context {
     ArrayList<String> addressesThatWereSet = new ArrayList<String>();
     if (setResponse != null) {
       if (setResponse.getStatus() == TpStateSetResponse.Status.AUTHORIZATION_ERROR) {
-  throw new InvalidTransactionException("Tried to set unauthorized address " + addressValuePairs.toString());
+        throw new InvalidTransactionException("Tried to set unauthorized address " + addressValuePairs.toString());
       }
       for (String address : setResponse.getAddressesList()) {
-  addressesThatWereSet.add(address);
+        addressesThatWereSet.add(address);
       }
     }
 
     return addressesThatWereSet;
+  }
+
+  @Override
+  public final Collection<String> deleteState(final Collection<String> addresses)
+      throws InternalError, InvalidTransactionException {
+    TpStateDeleteRequest delRequest = TpStateDeleteRequest.newBuilder().addAllAddresses(addresses)
+        .setContextId(this.contextId).build();
+    Future future = stream.send(Message.MessageType.TP_STATE_DELETE_REQUEST, delRequest.toByteString());
+    TpStateDeleteResponse delResponse = null;
+    try {
+      delResponse = TpStateDeleteResponse.parseFrom(future.getResult(TIME_OUT));
+    } catch (InterruptedException iee) {
+      throw new InternalError(iee.toString());
+    } catch (InvalidProtocolBufferException ipbe) {
+      // server didn't respond with a DeleteResponse
+      throw new InternalError(ipbe.toString());
+    } catch (ValidatorConnectionError vce) {
+      throw new InternalError(vce.toString());
+    } catch (Exception e) {
+      throw new InternalError(e.toString());
+    }
+    List<String> results = new ArrayList<>();
+    if (delResponse != null) {
+      if (delResponse.getStatus() == TpStateDeleteResponse.Status.AUTHORIZATION_ERROR) {
+        throw new InvalidTransactionException("Tried to delete unauthorized address " + addresses.toString());
+      }
+      for (String entry : delResponse.getAddressesList()) {
+        results.add(entry);
+      }
+    }
+    if (results.isEmpty()) {
+      throw new InternalError("State Error, no addresses found for delete request:" + addresses.toString());
+    }
+
+    return results;
+  }
+
+  @Override
+  public final void addReceiptData(final ByteString data) throws InternalError {
+    TpReceiptAddDataRequest addDataRequest = TpReceiptAddDataRequest.newBuilder().setContextId(contextId).setData(data)
+        .build();
+    Future future = stream.send(Message.MessageType.TP_RECEIPT_ADD_DATA_REQUEST, addDataRequest.toByteString());
+    TpReceiptAddDataResponse addDataResponse = null;
+    try {
+      addDataResponse = TpReceiptAddDataResponse.parseFrom(future.getResult(TIME_OUT));
+    } catch (InterruptedException iee) {
+      throw new InternalError(iee.toString());
+    } catch (InvalidProtocolBufferException ipbe) {
+      // server didn't respond with a ReceiptAddResponse
+      throw new InternalError(ipbe.toString());
+    } catch (ValidatorConnectionError vce) {
+      throw new InternalError(vce.toString());
+    } catch (Exception e) {
+      throw new InternalError(e.toString());
+    }
+    if (addDataResponse != null) {
+      if (addDataResponse.getStatus() == TpReceiptAddDataResponse.Status.ERROR) {
+        throw new InternalError(String.format("Failed to add receipt data %s", data));
+      }
+    }
+  }
+
+  @Override
+  public final void addEvent(final String eventType, final Collection<Entry<String, String>> attributes,
+      final ByteString data) throws InternalError {
+    List<Attribute> attList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : attributes) {
+      Attribute att = Attribute.newBuilder().setKey(entry.getKey()).setValue(entry.getValue()).build();
+      attList.add(att);
+    }
+    Builder evtBuilder = Event.newBuilder().addAllAttributes(attList).setEventType(eventType);
+    if (data != null) {
+      evtBuilder.setData(data);
+    }
+    Event evt = evtBuilder.build();
+    TpEventAddRequest evtAddRequest = TpEventAddRequest.newBuilder().setContextId(contextId).setEvent(evt).build();
+
+    Future future = stream.send(Message.MessageType.TP_EVENT_ADD_REQUEST, evtAddRequest.toByteString());
+    TpEventAddResponse evtAddResponse = null;
+    try {
+      evtAddResponse = TpEventAddResponse.parseFrom(future.getResult(TIME_OUT));
+    } catch (InterruptedException iee) {
+      throw new InternalError(iee.toString());
+    } catch (InvalidProtocolBufferException ipbe) {
+      // server didn't respond with a EventAddResponse
+      throw new InternalError(ipbe.toString());
+    } catch (ValidatorConnectionError vce) {
+      throw new InternalError(vce.toString());
+    } catch (Exception e) {
+      throw new InternalError(e.toString());
+    }
+    if (evtAddResponse != null) {
+      if (evtAddResponse.getStatus() == TpEventAddResponse.Status.ERROR) {
+        throw new InternalError(String.format("Failed to add event %s, %s, %s", eventType, attributes, data));
+      }
+    }
   }
 
 }

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
@@ -1,0 +1,331 @@
+package sawtooth.sdk.processor;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+
+import net.bytebuddy.utility.RandomString;
+import sawtooth.sdk.messaging.FutureByteString;
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.protobuf.TpEventAddResponse;
+import sawtooth.sdk.protobuf.TpEventAddResponse.Status;
+import sawtooth.sdk.protobuf.TpReceiptAddDataResponse;
+import sawtooth.sdk.protobuf.TpStateDeleteResponse;
+import sawtooth.sdk.protobuf.TpStateEntry;
+import sawtooth.sdk.protobuf.TpStateEntryOrBuilder;
+import sawtooth.sdk.protobuf.TpStateGetResponse;
+import sawtooth.sdk.protobuf.TpStateSetResponse;
+
+public class StreamContextTest {
+
+  @Test
+  public void testAddEvent() {
+    Stream stream = mock(Stream.class);
+
+    Context ctx = new StreamContext(stream, "test-context-id");
+
+    Map<String, String> testMap = new HashMap<>();
+    testMap.put("testKey1", "testValue1");
+    testMap.put("testKey2", "testValue2");
+    ByteString bs = ByteString.copyFromUtf8("testData");
+
+    FutureByteString okResponse = new FutureByteString("test-correlation-id");
+    okResponse
+        .setResult(TpEventAddResponse.newBuilder().setStatus(TpEventAddResponse.Status.OK).build().toByteString());
+
+    FutureByteString errResponse = new FutureByteString("test-correlation-id");
+    errResponse
+        .setResult(TpEventAddResponse.newBuilder().setStatus(TpEventAddResponse.Status.ERROR).build().toByteString());
+
+    FutureByteString garbageResponse = new FutureByteString("test-correlation-id");
+    garbageResponse.setResult(ByteString.copyFrom("something-garbage-like".getBytes()));
+
+    try {
+      when(stream.send(any(), any())).thenReturn(okResponse);
+      ctx.addEvent("test-event", testMap.entrySet(), bs);
+    } catch (InternalError exc) {
+      fail("Happy path should not generate an InternalError");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(garbageResponse);
+      ctx.addEvent("test-event", testMap.entrySet(), bs);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      // Expected
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(errResponse);
+      ctx.addEvent("test-event", testMap.entrySet(), bs);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testAddReceiptData() {
+    Stream stream = mock(Stream.class);
+
+    Context ctx = new StreamContext(stream, "test-context-id");
+
+    Map<String, String> testMap = new HashMap<>();
+    testMap.put("testKey1", "testValue1");
+    testMap.put("testKey2", "testValue2");
+    ByteString bs = ByteString.copyFromUtf8("testData");
+
+    FutureByteString okResponse = new FutureByteString("test-correlation-id");
+    okResponse.setResult(
+        TpReceiptAddDataResponse.newBuilder().setStatus(TpReceiptAddDataResponse.Status.OK).build().toByteString());
+
+    FutureByteString errResponse = new FutureByteString("test-correlation-id");
+    errResponse.setResult(
+        TpReceiptAddDataResponse.newBuilder().setStatus(TpReceiptAddDataResponse.Status.ERROR).build().toByteString());
+
+    FutureByteString garbageResponse = new FutureByteString("test-correlation-id");
+    garbageResponse.setResult(ByteString.copyFrom("something-garbage-like".getBytes()));
+
+    try {
+      when(stream.send(any(), any())).thenReturn(okResponse);
+      ctx.addReceiptData(bs);
+    } catch (InternalError exc) {
+      fail("Happy path should not generate an InternalError");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(garbageResponse);
+      ctx.addReceiptData(bs);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      // Expected
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(errResponse);
+      ctx.addReceiptData(bs);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testDeleteState() {
+    Stream stream = mock(Stream.class);
+
+    Context ctx = new StreamContext(stream, "test-context-id");
+
+    List<String> deleteList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      deleteList.add(RandomString.make(70));
+    }
+
+    FutureByteString okResponse = new FutureByteString("test-correlation-id");
+    TpStateDeleteResponse deleteReponse = TpStateDeleteResponse.newBuilder().setStatus(TpStateDeleteResponse.Status.OK)
+        .addAllAddresses(deleteList).build();
+    okResponse.setResult(deleteReponse.toByteString());
+
+    FutureByteString emptyResponse = new FutureByteString("test-correlation-id");
+    TpStateDeleteResponse emptyDeleteReponse = TpStateDeleteResponse.newBuilder()
+        .setStatus(TpStateDeleteResponse.Status.OK).addAllAddresses(new ArrayList<String>()).build();
+    emptyResponse.setResult(emptyDeleteReponse.toByteString());
+
+    FutureByteString errResponse = new FutureByteString("test-correlation-id");
+    errResponse.setResult(TpStateDeleteResponse.newBuilder().setStatus(TpStateDeleteResponse.Status.AUTHORIZATION_ERROR)
+        .build().toByteString());
+
+    FutureByteString garbageResponse = new FutureByteString("test-correlation-id");
+    garbageResponse.setResult(ByteString.copyFrom("something-garbage-like".getBytes()));
+
+    try {
+      when(stream.send(any(), any())).thenReturn(okResponse);
+      Collection<String> addressesDeleted = ctx.deleteState(deleteList);
+      // Compare the in and out addresses, without trusting that either are ordered
+      Set<String> inSet = new HashSet<>(deleteList);
+      Set<String> outSet = new HashSet<>(addressesDeleted);
+      if (!inSet.equals(outSet)) {
+        fail("Addresses requested to be deleted do not match those which were actually deleted");
+      }
+    } catch (InternalError exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(emptyResponse);
+      Collection<String> addressesDeleted = ctx.deleteState(deleteList);
+      fail("Returning an empty list of deleted addresses should have resulted in an InternalError");
+    } catch (InternalError exc) {
+      // Expected
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail("Empty path should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(garbageResponse);
+      Collection<String> addressesDeleted = ctx.deleteState(deleteList);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      // Expected
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail(" should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(errResponse);
+      Collection<String> addressesDeleted = ctx.deleteState(deleteList);
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      ie.printStackTrace();
+      fail(" should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testGetState() throws UnsupportedEncodingException {
+    Stream stream = mock(Stream.class);
+
+    Context ctx = new StreamContext(stream, "test-context-id");
+
+    Map<String, ByteString> getMap = new HashMap<>();
+    List<TpStateEntry> entryList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      String key = RandomString.make(70);
+      ByteString value = ByteString.copyFrom(RandomString.make(10), "UTF-8");
+      getMap.put(key, value);
+      TpStateEntry entry = TpStateEntry.newBuilder().setAddress(key).setData(value).build();
+      entryList.add(entry);
+    }
+
+    FutureByteString okResponse = new FutureByteString("test-correlation-id");
+    TpStateGetResponse validReponse = TpStateGetResponse.newBuilder().setStatus(TpStateGetResponse.Status.OK)
+        .addAllEntries(entryList).build();
+    okResponse.setResult(validReponse.toByteString());
+
+    FutureByteString emptyResponse = new FutureByteString("test-correlation-id");
+    TpStateGetResponse emptyGetReponse = TpStateGetResponse.newBuilder().setStatus(TpStateGetResponse.Status.OK)
+        .addAllEntries(new ArrayList<TpStateEntry>()).build();
+    emptyResponse.setResult(emptyGetReponse.toByteString());
+
+    FutureByteString errResponse = new FutureByteString("test-correlation-id");
+    errResponse.setResult(TpStateGetResponse.newBuilder().setStatus(TpStateGetResponse.Status.AUTHORIZATION_ERROR)
+        .build().toByteString());
+
+    try {
+      when(stream.send(any(), any())).thenReturn(okResponse);
+      Map<String, ByteString> resultMap = ctx.getState(getMap.keySet());
+
+      if (!resultMap.equals(getMap)) {
+        fail("getState returned a different result than we asked for");
+      }
+    } catch (InternalError exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(emptyResponse);
+      Map<String, ByteString> resultMap = ctx.getState(getMap.keySet());
+      fail("Returning an empty list of deleted addresses should have resulted in an InternalError");
+    } catch (InternalError exc) {
+      // Expected
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail("Empty path should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(errResponse);
+      Map<String, ByteString> resultMap = ctx.getState(getMap.keySet());
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      ie.printStackTrace();
+      fail(" should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testSetState() throws UnsupportedEncodingException {
+    Stream stream = mock(Stream.class);
+
+    Context ctx = new StreamContext(stream, "test-context-id");
+
+    Map<String, ByteString> getMap = new HashMap<>();
+    List<TpStateEntry> entryList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      String key = RandomString.make(70);
+      ByteString value = ByteString.copyFrom(RandomString.make(10), "UTF-8");
+      getMap.put(key, value);
+      TpStateEntry entry = TpStateEntry.newBuilder().setAddress(key).setData(value).build();
+      entryList.add(entry);
+    }
+
+    FutureByteString okResponse = new FutureByteString("test-correlation-id");
+    TpStateSetResponse validReponse = TpStateSetResponse.newBuilder().setStatus(TpStateSetResponse.Status.OK)
+        .addAllAddresses(getMap.keySet()).build();
+    okResponse.setResult(validReponse.toByteString());
+
+    FutureByteString errResponse = new FutureByteString("test-correlation-id");
+    errResponse.setResult(TpStateSetResponse.newBuilder().setStatus(TpStateSetResponse.Status.AUTHORIZATION_ERROR)
+        .build().toByteString());
+
+    try {
+      when(stream.send(any(), any())).thenReturn(okResponse);
+      Collection<String> result = ctx.setState(getMap.entrySet());
+
+      Set<String> outSet = new HashSet<>(result);
+      if (!getMap.keySet().equals(outSet)) {
+        fail("Addresses requested to be set do not match those which were actually set");
+      }
+
+    } catch (InternalError exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      exc.printStackTrace();
+      fail("Happy path should not generate an InvalidTransactionException");
+    }
+
+    try {
+      when(stream.send(any(), any())).thenReturn(errResponse);
+      Collection<String> result = ctx.setState(getMap.entrySet());
+      fail("An error should have been thrown since we responded with something wrong!");
+    } catch (InternalError ie) {
+      ie.printStackTrace();
+      fail(" should not generate an InternalError");
+    } catch (InvalidTransactionException exc) {
+      // Expected
+    }
+  }
+
+}

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
@@ -175,9 +175,8 @@ public class StreamContextTest {
     try {
       when(stream.send(any(), any())).thenReturn(emptyResponse);
       Collection<String> addressesDeleted = ctx.deleteState(deleteList);
-      fail("Returning an empty list of deleted addresses should have resulted in an InternalError");
     } catch (InternalError exc) {
-      // Expected
+      fail("Returning an empty list of deleted addresses should not result in an InternalError");
     } catch (InvalidTransactionException exc) {
       exc.printStackTrace();
       fail("Empty path should not generate an InvalidTransactionException");
@@ -254,9 +253,8 @@ public class StreamContextTest {
     try {
       when(stream.send(any(), any())).thenReturn(emptyResponse);
       Map<String, ByteString> resultMap = ctx.getState(getMap.keySet());
-      fail("Returning an empty list of deleted addresses should have resulted in an InternalError");
     } catch (InternalError exc) {
-      // Expected
+      fail("Returning an empty map of entries should not result in an InternalError");
     } catch (InvalidTransactionException exc) {
       exc.printStackTrace();
       fail("Empty path should not generate an InvalidTransactionException");

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
@@ -1,5 +1,6 @@
 package sawtooth.sdk.processor;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -12,7 +13,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 import org.junit.Test;
@@ -25,11 +25,9 @@ import sawtooth.sdk.messaging.Stream;
 import sawtooth.sdk.processor.exceptions.InternalError;
 import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
 import sawtooth.sdk.protobuf.TpEventAddResponse;
-import sawtooth.sdk.protobuf.TpEventAddResponse.Status;
 import sawtooth.sdk.protobuf.TpReceiptAddDataResponse;
 import sawtooth.sdk.protobuf.TpStateDeleteResponse;
 import sawtooth.sdk.protobuf.TpStateEntry;
-import sawtooth.sdk.protobuf.TpStateEntryOrBuilder;
 import sawtooth.sdk.protobuf.TpStateGetResponse;
 import sawtooth.sdk.protobuf.TpStateSetResponse;
 
@@ -175,6 +173,7 @@ public class StreamContextTest {
     try {
       when(stream.send(any(), any())).thenReturn(emptyResponse);
       Collection<String> addressesDeleted = ctx.deleteState(deleteList);
+      assertTrue("addressesDeleted should be empty", addressesDeleted.isEmpty());
     } catch (InternalError exc) {
       fail("Returning an empty list of deleted addresses should not result in an InternalError");
     } catch (InvalidTransactionException exc) {
@@ -253,6 +252,7 @@ public class StreamContextTest {
     try {
       when(stream.send(any(), any())).thenReturn(emptyResponse);
       Map<String, ByteString> resultMap = ctx.getState(getMap.keySet());
+      assertTrue("resultMap should be empty", resultMap.isEmpty());
     } catch (InternalError exc) {
       fail("Returning an empty map of entries should not result in an InternalError");
     } catch (InvalidTransactionException exc) {


### PR DESCRIPTION
- Enabled checkstyle for transaction-processor module
- style: some whitespace corrected, and imports ordering corrected
- Added deleteState, addReceiptData, and addEvent methods and implementation as requested in https://jira.hyperledger.org/browse/STL-1175