### PR TITLE
Add threading

### DIFF
--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/MessageWrapper.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/MessageWrapper.java
@@ -1,0 +1,43 @@
+/* Copyright 2016,  2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package sawtooth.sdk.messaging;
+
+import sawtooth.sdk.protobuf.Message;
+
+/**
+ * Inner class for passing messages.
+ */
+public final class MessageWrapper {
+  /**
+   * The protobuf Message.
+   */
+  private Message message;
+
+  /** Constructor.
+   *
+   * @param msg The protobuf Message.
+   */
+  MessageWrapper(final Message msg) {
+    this.message = msg;
+  }
+
+  /** Return the Message associated with this MessageWrapper.
+   *
+   * @return Message the message.
+   */
+  public Message getMessage() {
+    return message;
+  }
+}

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
@@ -92,34 +92,8 @@ class SendReceiveThread implements Runnable {
   }
 
   /**
-   * Inner class for passing messages.
-   */
-  class MessageWrapper {
-    /**
-     * The protobuf Message.
-     */
-    private Message message;
-
-    /**
-     * Constructor.
-     * @param msg The protobuf Message.
-     */
-    MessageWrapper(final Message msg) {
-      this.message = msg;
-    }
-
-    /**
-     * Return the Message associated with this MessageWrapper.
-     * @return Message the message.
-     */
-    public Message getMessage() {
-      return message;
-    }
-  }
-
-  /**
-   * DisconnectThread is run to handle the validator disconnecting on the other
-   * side of the ZMQ connection.
+   * DisconnectThread is run to handle the validator disconnecting on the other side of the ZMQ
+   * connection.
    */
   private class DisconnectThread extends Thread {
 

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Stream.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Stream.java
@@ -14,6 +14,7 @@
 
 package sawtooth.sdk.messaging;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeoutException;
 
 import com.google.protobuf.ByteString;
@@ -62,4 +63,9 @@ public interface Stream extends AutoCloseable {
    */
   Message receive(long timeout) throws TimeoutException;
 
+  /**
+   * Get a message queue that this stream will publish messages to.
+   * @return a BlockingQueue for the consumer can take messages from.
+   */
+  BlockingQueue<MessageWrapper> getReceiveQueue();
 }

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionHandlerTask.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionHandlerTask.java
@@ -1,0 +1,91 @@
+/* Copyright 2019 Hyperledger Sawtooth Contributors
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+package sawtooth.sdk.processor;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.TpProcessRequest;
+import sawtooth.sdk.protobuf.TpProcessResponse;
+
+/**
+ * A runnable task to execute a TransactionProcessorHandler for a single
+ * transaction.
+ */
+public class TransactionHandlerTask implements Runnable {
+
+  /** Logging class for this processor. */
+  private static final Logger LOGGER = Logger.getLogger(TransactionHandlerTask.class.getName());
+
+  /** Message this task with handle. */
+  private final Message message;
+
+  /** Stream this task will use to communicate. */
+  private final Stream stream;
+
+  /** TP Handler this task will use. */
+  private final TransactionHandler handler;
+
+  /**
+   * Create a TransactionHandler task.
+   * @param msg         The message to be processed
+   * @param replyStream The stream on which the handler will respond
+   * @param txHandler   the handler
+   */
+  public TransactionHandlerTask(final Message msg, final Stream replyStream, final TransactionHandler txHandler) {
+    this.message = msg;
+    this.stream = replyStream;
+    this.handler = txHandler;
+  }
+
+  @Override
+  public final void run() {
+    try {
+      TpProcessRequest transactionRequest = TpProcessRequest.parseFrom(message.getContent());
+      Context state = new StreamContext(stream, transactionRequest.getContextId());
+
+      TpProcessResponse.Builder builder = TpProcessResponse.newBuilder();
+      try {
+        handler.apply(transactionRequest, state);
+        builder.setStatus(TpProcessResponse.Status.OK);
+      } catch (InvalidTransactionException ite) {
+        LOGGER.log(Level.FINE, "Invalid Transaction: " + ite.toString());
+        builder.setStatus(TpProcessResponse.Status.INVALID_TRANSACTION);
+        builder.setMessage(ite.getMessage());
+        if (ite.getExtendedData() != null) {
+          builder.setExtendedData(ByteString.copyFrom(ite.getExtendedData()));
+        }
+      } catch (InternalError ie) {
+        LOGGER.log(Level.WARNING, "Internal Error: " + ie.toString());
+        builder.setStatus(TpProcessResponse.Status.INTERNAL_ERROR);
+        builder.setMessage(ie.getMessage());
+        if (ie.getExtendedData() != null) {
+          builder.setExtendedData(ByteString.copyFrom(ie.getExtendedData()));
+        }
+      }
+      stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE, message.getCorrelationId(),
+          builder.build().toByteString());
+
+    } catch (InvalidProtocolBufferException ipbe) {
+      LOGGER.log(Level.INFO, "Received Bytestring that wasn't requested that isn't TransactionProcessRequest", ipbe);
+    }
+  }
+}

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -214,6 +214,17 @@ public class TransactionProcessor implements Runnable {
     TransactionHandler handler = findHandler(message);
     if (handler == null) {
       // No handler available for this message, noop
+      TpProcessRequest transactionRequest;
+      try {
+        transactionRequest = TpProcessRequest.parseFrom(message.getContent());
+        TransactionHeader header = transactionRequest.getHeader();
+        String familyName = header.getFamilyName();
+        String familyVersion = header.getFamilyVersion();
+        LOGGER.log(Level.WARNING, String.format("No handler for message type: family=%s version=%s",
+            familyName, familyVersion));
+      } catch (InvalidProtocolBufferException exc) {
+        LOGGER.log(Level.WARNING, "Unparseable message", exc);
+      }
       return;
     }
     TransactionHandlerTask task = new TransactionHandlerTask(message, this.stream, handler);

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -60,7 +60,7 @@ public class TransactionProcessor implements Runnable {
   private AtomicBoolean registered;
 
   /** Flag signifying whether or not this thread should keep running. */
-  private AtomicBoolean keepRunning;
+  private AtomicBoolean running;
 
   /** An ExecutorService for this processor. */
   private ExecutorService executorService;
@@ -101,7 +101,7 @@ public class TransactionProcessor implements Runnable {
     this.stream = customStream;
     this.handlers = Collections.synchronizedMap(new HashMap<>());
     this.registered = new AtomicBoolean(false);
-    this.keepRunning = new AtomicBoolean(true);
+    this.running = new AtomicBoolean(true);
     this.setMaxOccupancy(Runtime.getRuntime().availableProcessors());
     this.executorService = Executors.newWorkStealingPool(getMaxOccupancy());
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -171,7 +171,7 @@ public class TransactionProcessor implements Runnable {
     } catch (ValidatorConnectionError exc) {
       LOGGER.log(Level.INFO, "Connection error while unregistering", exc);
     }
-    this.keepRunning.compareAndSet(true, false);
+    this.running.compareAndSet(true, false);
   }
 
   /**
@@ -236,7 +236,7 @@ public class TransactionProcessor implements Runnable {
 
   @Override
   public final void run() {
-    while (keepRunning.get()) {
+    while (running.get()) {
       registerHandlers();
       Message currentMessage;
       if (!this.handlers.isEmpty()) {

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -68,9 +68,8 @@ public class TransactionProcessor implements Runnable {
       try {
         TpUnregisterRequest unregisterRequest = TpUnregisterRequest.newBuilder().build();
         LOGGER.info("Send TpUnregisterRequest");
-        Future fut =
-            TransactionProcessor.this.stream.send(
-                Message.MessageType.TP_UNREGISTER_REQUEST, unregisterRequest.toByteString());
+        Future fut = TransactionProcessor.this.stream.send(Message.MessageType.TP_UNREGISTER_REQUEST,
+            unregisterRequest.toByteString());
         ByteString response = fut.getResult(1);
         Message message = TransactionProcessor.this.getCurrentMessage();
         if (message == null) {
@@ -94,7 +93,6 @@ public class TransactionProcessor implements Runnable {
 
   /**
    * constructor.
-   *
    * @param address the zmq address
    */
   public TransactionProcessor(final String address) {
@@ -107,20 +105,13 @@ public class TransactionProcessor implements Runnable {
 
   /**
    * add a handler that will be run from within the run method.
-   *
    * @param handler implements that TransactionHandler interface
    */
   public final void addHandler(final TransactionHandler handler) {
-    TpRegisterRequest registerRequest =
-        TpRegisterRequest.newBuilder()
-            .setFamily(handler.transactionFamilyName())
-            .addAllNamespaces(handler.getNameSpaces())
-            .setVersion(handler.getVersion())
-            .setMaxOccupancy(1)
-            .build();
+    TpRegisterRequest registerRequest = TpRegisterRequest.newBuilder().setFamily(handler.transactionFamilyName())
+        .addAllNamespaces(handler.getNameSpaces()).setVersion(handler.getVersion()).setMaxOccupancy(1).build();
     try {
-      Future fut =
-          this.stream.send(Message.MessageType.TP_REGISTER_REQUEST, registerRequest.toByteString());
+      Future fut = this.stream.send(Message.MessageType.TP_REGISTER_REQUEST, registerRequest.toByteString());
       fut.getResult();
       this.registered = true;
       this.handlers.add(handler);
@@ -133,7 +124,6 @@ public class TransactionProcessor implements Runnable {
 
   /**
    * Get the current message that is being processed.
-   *
    * @return the current message
    */
   private Message getCurrentMessage() {
@@ -142,13 +132,11 @@ public class TransactionProcessor implements Runnable {
 
   /**
    * Used to process a message.
-   *
    * @param message The Message to process.
-   * @param stream The Stream to use to send back responses.
+   * @param stream  The Stream to use to send back responses.
    * @param handler The handler that should be used to process the message.
    */
-  private static void process(
-      final Message message, final Stream stream, final TransactionHandler handler) {
+  private static void process(final Message message, final Stream stream, final TransactionHandler handler) {
     try {
       TpProcessRequest transactionRequest = TpProcessRequest.parseFrom(message.getContent());
       Context state = new StreamContext(stream, transactionRequest.getContextId());
@@ -172,9 +160,7 @@ public class TransactionProcessor implements Runnable {
           builder.setExtendedData(ByteString.copyFrom(ie.getExtendedData()));
         }
       }
-      stream.sendBack(
-          Message.MessageType.TP_PROCESS_RESPONSE,
-          message.getCorrelationId(),
+      stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE, message.getCorrelationId(),
           builder.build().toByteString());
 
     } catch (InvalidProtocolBufferException ipbe) {
@@ -184,15 +170,13 @@ public class TransactionProcessor implements Runnable {
 
   /**
    * Find the handler that should be used to process the given message.
-   *
-   * @param message The message that has the TpProcessRequest that the header that will be checked
-   *     against the handler.
+   * @param message The message that has the TpProcessRequest that the header that
+   *                will be checked against the handler.
    * @return the handler that should be used to processor the given message
    */
   private TransactionHandler findHandler(final Message message) {
     try {
-      TpProcessRequest transactionRequest =
-          TpProcessRequest.parseFrom(this.currentMessage.getContent());
+      TpProcessRequest transactionRequest = TpProcessRequest.parseFrom(this.currentMessage.getContent());
       TransactionHeader header = transactionRequest.getHeader();
       for (int i = 0; i < this.handlers.size(); i++) {
         TransactionHandler handler = this.handlers.get(i);
@@ -218,13 +202,10 @@ public class TransactionProcessor implements Runnable {
           if (this.currentMessage.getMessageType() == Message.MessageType.PING_REQUEST) {
             LOGGER.info("Recieved Ping Message.");
             PingResponse pingResponse = PingResponse.newBuilder().build();
-            this.stream.sendBack(
-                Message.MessageType.PING_RESPONSE,
-                this.currentMessage.getCorrelationId(),
+            this.stream.sendBack(Message.MessageType.PING_RESPONSE, this.currentMessage.getCorrelationId(),
                 pingResponse.toByteString());
             this.currentMessage = null;
-          } else if (this.currentMessage.getMessageType()
-              == Message.MessageType.TP_PROCESS_REQUEST) {
+          } else if (this.currentMessage.getMessageType() == Message.MessageType.TP_PROCESS_REQUEST) {
             TransactionHandler handler = this.findHandler(this.currentMessage);
             if (handler == null) {
               break;
@@ -241,17 +222,12 @@ public class TransactionProcessor implements Runnable {
           this.registered = false;
           for (int i = 0; i < this.handlers.size(); i++) {
             TransactionHandler handler = this.handlers.get(i);
-            TpRegisterRequest registerRequest =
-                TpRegisterRequest.newBuilder()
-                    .setFamily(handler.transactionFamilyName())
-                    .addAllNamespaces(handler.getNameSpaces())
-                    .setVersion(handler.getVersion())
-                    .build();
+            TpRegisterRequest registerRequest = TpRegisterRequest.newBuilder()
+                .setFamily(handler.transactionFamilyName()).addAllNamespaces(handler.getNameSpaces())
+                .setVersion(handler.getVersion()).build();
 
             try {
-              Future fut =
-                  this.stream.send(
-                      Message.MessageType.TP_REGISTER_REQUEST, registerRequest.toByteString());
+              Future fut = this.stream.send(Message.MessageType.TP_REGISTER_REQUEST, registerRequest.toByteString());
               fut.getResult();
               this.registered = true;
             } catch (InterruptedException ie) {

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/StreamContextTest.java
@@ -31,8 +31,34 @@ import sawtooth.sdk.protobuf.TpStateEntry;
 import sawtooth.sdk.protobuf.TpStateGetResponse;
 import sawtooth.sdk.protobuf.TpStateSetResponse;
 
+/* Copyright 2019 Hyperledger Sawtooth Contributors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------------------*/
 public class StreamContextTest {
 
+  /**
+   * This is a behavioral test of the TransactionHandlerTask. The following
+   * interactions are tested:
+   * <ul>
+   * <li>A valid transaction is handled and an OK response is expected</li>
+   * <li>An invalid transaction is handled and an INVALID_TRANSACTION response is
+   * expected</li>
+   * <li>A transaction which produces an InternalError is handled and an
+   * INTERNAL_ERROR response is expected</li>
+   * </ul>
+   * Finally there is a verification that exactly the expected number of calls to
+   * Stream.sendBack are made.
+   */
   @Test
   public void testAddEvent() {
     Stream stream = mock(Stream.class);

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionHandlerTaskTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionHandlerTaskTest.java
@@ -1,0 +1,97 @@
+/* Copyright 2019 Hyperledger Sawtooth Contributors
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+package sawtooth.sdk.processor;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.Message.MessageType;
+import sawtooth.sdk.protobuf.TpProcessResponse;
+
+public class TransactionHandlerTaskTest {
+
+  TpProcessResponse response;
+
+  @Test
+  public void testRun() {
+
+    Stream replyStream = mock(Stream.class);
+    TransactionHandler txHandler = mock(TransactionHandler.class);
+    TransactionHandlerTask task = new TransactionHandlerTask(Message.getDefaultInstance(), replyStream, txHandler);
+
+    try {
+      response = null;
+      doAnswer(new Answer<Void>() {
+        public Void answer(InvocationOnMock invocation) {
+          Object[] args = invocation.getArguments();
+          ByteString contents = (ByteString) args[2];
+          try {
+            response = TpProcessResponse.parseFrom(contents);
+          } catch (InvalidProtocolBufferException exc) {
+            fail("Sent back an invalid message!");
+          }
+          return null;
+        }
+      }).when(replyStream).sendBack(any(), any(), any());
+
+      task.run();
+      verify(replyStream, times(1)).sendBack(eq(MessageType.TP_PROCESS_RESPONSE), any(String.class),
+          any(ByteString.class));
+      assertNotNull(response);
+      assertTrue(response.getStatus() == TpProcessResponse.Status.OK);
+
+      response = null;
+      InvalidTransactionException ite = new InvalidTransactionException("Expected InvalidTransactionException",
+          new byte[] {});
+      doThrow(ite).when(txHandler).apply(any(), any());
+      task.run();
+      verify(replyStream, times(2)).sendBack(eq(MessageType.TP_PROCESS_RESPONSE), any(String.class),
+          any(ByteString.class));
+      assertNotNull(response);
+      assertTrue(response.getStatus() == TpProcessResponse.Status.INVALID_TRANSACTION);
+
+      response = null;
+      InternalError ie = new InternalError("Expected InternalError", new byte[] {});
+      doThrow(ie).when(txHandler).apply(any(), any());
+      task.run();
+      verify(replyStream, times(3)).sendBack(eq(MessageType.TP_PROCESS_RESPONSE), any(String.class),
+          any(ByteString.class));
+      assertNotNull(response);
+      assertTrue(response.getStatus() == TpProcessResponse.Status.INTERNAL_ERROR);
+
+    } catch (InvalidTransactionException | InternalError exc) {
+      fail("No exceptions should be thrown");
+    }
+  }
+
+}

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionProcessorTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionProcessorTest.java
@@ -133,30 +133,19 @@ public class TransactionProcessorTest {
     when(handler.getVersion()).thenReturn(testVersion);
     
     tp.addHandler(handler);
-    ExecutorService svc = Executors.newFixedThreadPool(1);
-    svc.submit(tp);
-
-    // Wait a moment for things to execute before shutting down
-    synchronized (svc) {
-      try {
-        svc.wait(1000);
-      } catch (InterruptedException exc) {
-        fail("Interrupted while waiting!");
-      }
-    }
+    
     try {
+      tp.handleMessage(msg);
+      tp.handleMessage(msgNoFamily);
+      tp.handleMessage(null);
+      tp.handleMessage(pingMessage);
+    
       verify(handler,times(1)).apply(any(), any());
-      verify(stream,atLeast(2)).sendBack(any(), any(), any());
+      verify(stream,times(2)).sendBack(any(), any(), any());
     } catch (InvalidTransactionException | InternalError exc1) {
       fail("No Exceptions should be thrown");
     } 
     tp.stopProcessor();
-    svc.shutdown();
-    try {
-      svc.awaitTermination(30, TimeUnit.SECONDS);
-    } catch (InterruptedException exc) {
-      fail("The shutdown was interrupted!");
-    }
   }
 
   @Test

--- a/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionProcessorTest.java
+++ b/sawtooth-sdk-transaction-processor/src/test/java/sawtooth/sdk/processor/TransactionProcessorTest.java
@@ -1,0 +1,174 @@
+/* Copyright 2019 Hyperledger Sawtooth Contributors
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+package sawtooth.sdk.processor;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.google.protobuf.ByteString;
+
+import net.bytebuddy.utility.RandomString;
+import sawtooth.sdk.messaging.Future;
+import sawtooth.sdk.messaging.FutureByteString;
+import sawtooth.sdk.messaging.Stream;
+import sawtooth.sdk.processor.exceptions.InternalError;
+import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
+import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.Message.MessageType;
+import sawtooth.sdk.protobuf.TpProcessRequest;
+import sawtooth.sdk.protobuf.TransactionHeader;
+
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class TransactionProcessorTest {
+
+  private static final String testFamily = RandomString.make(6);
+  private static final String testVersion = RandomString.make(4);
+
+  @Test
+  public void testAddFindHandler() {
+    Stream stream = mock(Stream.class);
+    TransactionProcessor tp = new TransactionProcessor(stream);
+
+    TransactionHandler handler = mock(TransactionHandler.class);
+    when(handler.transactionFamilyName()).thenReturn(testFamily);
+    when(handler.getVersion()).thenReturn(testVersion);
+
+    TransactionHandler handler2 = mock(TransactionHandler.class);
+    when(handler2.transactionFamilyName()).thenReturn(testFamily);
+    when(handler2.getVersion()).thenReturn(testVersion);
+
+    tp.addHandler(handler);
+
+    TransactionHeader header = TransactionHeader.newBuilder().setFamilyName(testFamily).setFamilyVersion(testVersion)
+        .build();
+    TpProcessRequest req = TpProcessRequest.newBuilder().setHeader(header).build();
+    Message msg = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST).setContent(req.toByteString())
+        .build();
+    TransactionHandler testHandler = tp.findHandler(msg);
+    assertTrue("TransactionProcessor should find the same handler we used before!", handler.equals(testHandler));
+
+    tp.addHandler(handler2);
+    header = TransactionHeader.newBuilder().setFamilyName(testFamily).setFamilyVersion(testVersion).build();
+    req = TpProcessRequest.newBuilder().setHeader(header).build();
+
+    msg = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST).setContent(req.toByteString()).build();
+    testHandler = tp.findHandler(msg);
+    assertTrue("TransactionProcessor should not find the same handler we used before, since we replaced it!",
+        !handler.equals(testHandler));
+
+    tp.addHandler(handler2);
+    header = TransactionHeader.newBuilder().setFamilyName(testFamily).setFamilyVersion(testVersion).build();
+    req = TpProcessRequest.newBuilder().setHeader(header).build();
+
+    msg = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST).setContent(req.toByteString()).build();
+    testHandler = tp.findHandler(msg);
+    assertTrue("TransactionProcessor should find the same handler we used before, since we added it again!",
+        handler2.equals(testHandler));
+
+    header = TransactionHeader.newBuilder().setFamilyName(testFamily + "someother")
+        .setFamilyVersion(testVersion + "someother").build();
+    req = TpProcessRequest.newBuilder().setHeader(header).build();
+    Message msgNewFamily = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST)
+        .setContent(req.toByteString()).build();
+    testHandler = tp.findHandler(msgNewFamily);
+    assertNull("TransactionProcessor should not find a handler for this message with a new family!", testHandler);
+
+    header = TransactionHeader.newBuilder().setFamilyName(testFamily).setFamilyVersion(testVersion + "someother")
+        .build();
+    req = TpProcessRequest.newBuilder().setHeader(header).build();
+    Message msgNewVersion = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST)
+        .setContent(req.toByteString()).build();
+    testHandler = tp.findHandler(msgNewVersion);
+    assertNull("TransactionProcessor should not find a handler for this message with an old family but new version!",
+        testHandler);
+  }
+
+  @Test
+  public void testRun() {
+    Stream stream = mock(Stream.class);
+    TransactionProcessor tp = new TransactionProcessor(stream);
+
+    TransactionHeader header = TransactionHeader.newBuilder().setFamilyName(testFamily).setFamilyVersion(testVersion)
+        .build();
+    TpProcessRequest req = TpProcessRequest.newBuilder().setHeader(header).build();
+    Message msg = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST).setContent(req.toByteString())
+        .build();
+
+    TransactionHeader headerNoFamily = TransactionHeader.newBuilder().setFamilyName("someother").setFamilyVersion(testVersion)
+        .build();
+    TpProcessRequest reqNoFamily = TpProcessRequest.newBuilder().setHeader(headerNoFamily).build();
+    Message msgNoFamily = Message.newBuilder().setMessageType(MessageType.TP_PROCESS_REQUEST).setContent(reqNoFamily.toByteString())
+        .build();
+    
+    Message pingMessage = Message.newBuilder().setMessageType(MessageType.PING_REQUEST).build();
+    
+    when(stream.receive()).thenReturn(msg,msgNoFamily,null,pingMessage);
+    Future f=new FutureByteString(RandomString.make(70));
+    try {
+      f.setResult(ByteString.EMPTY);
+    } catch (ValidatorConnectionError exc2) {
+    }
+    when(stream.send(any(), any())).thenReturn(f);
+
+    TransactionHandler handler = mock(TransactionHandler.class);
+    when(handler.transactionFamilyName()).thenReturn(testFamily);
+    when(handler.getVersion()).thenReturn(testVersion);
+    
+    tp.addHandler(handler);
+    ExecutorService svc = Executors.newFixedThreadPool(1);
+    svc.submit(tp);
+
+    // Wait a moment for things to execute before shutting down
+    synchronized (svc) {
+      try {
+        svc.wait(1000);
+      } catch (InterruptedException exc) {
+        fail("Interrupted while waiting!");
+      }
+    }
+    try {
+      verify(handler,times(1)).apply(any(), any());
+      verify(stream,atLeast(2)).sendBack(any(), any(), any());
+    } catch (InvalidTransactionException | InternalError exc1) {
+      fail("No Exceptions should be thrown");
+    } 
+    tp.stopProcessor();
+    svc.shutdown();
+    try {
+      svc.awaitTermination(30, TimeUnit.SECONDS);
+    } catch (InterruptedException exc) {
+      fail("The shutdown was interrupted!");
+    }
+  }
+
+  @Test
+  public void testSetGetMaxOccupancy() {
+    Stream stream = mock(Stream.class);
+    TransactionProcessor tp = new TransactionProcessor(stream);
+
+    int maxOccupancy = tp.getMaxOccupancy();
+    int newMaxOccuppancy = maxOccupancy + 1;
+    tp.setMaxOccupancy(newMaxOccuppancy);
+    maxOccupancy = tp.getMaxOccupancy();
+    assertTrue("setMaxOccuppancy has not applied!", maxOccupancy == newMaxOccuppancy);
+  }
+
+}


### PR DESCRIPTION
This pull adds multi-threaded processing to the TransactionProcessor class, without breaking the existing interface.  

- Calls to TransactionHandler.apply() are delegated to a TransactionHandlerTask, which is submitted to a workStealingPool.  
- TP Registration, and addHandler has been refactored to be threadsafe as well
- Unit tests for the TransactionHandlerTask,  and behavioral unit tests for TransactionProcessor