### PR TITLE
Resolution of some bugs in sawtooth.sdk.messaging

### DIFF
--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Future.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Future.java
@@ -20,40 +20,38 @@ import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
 
 import java.util.concurrent.TimeoutException;
 
-
 /**
  * An object that will have a value at some point.
  */
 public interface Future {
-  /** Block until the result is ready.
-   *
+  /**
+   * Block until the result is ready.
    * @return the result ByteString
-   * @throws InterruptedException An interrupt happened during the method call.
+   * @throws InterruptedException     An interrupt happened during the method
+   *                                  call.
    * @throws ValidatorConnectionError The validator disconnected.
    */
-  ByteString getResult() throws InterruptedException,
-      ValidatorConnectionError;
+  ByteString getResult() throws InterruptedException, ValidatorConnectionError;
 
-  /** Block until timeout, then throw TimeoutException if result is not available.
-   *
+  /**
+   * Block until timeout, then throw TimeoutException if result is not available.
    * @param timeout The amount of time to wait.
    * @return result ByteString
-   * @throws InterruptedException An interrupt happened.
-   * @throws TimeoutException The time to wait happened.
+   * @throws InterruptedException     An interrupt happened.
+   * @throws TimeoutException         The time to wait happened.
    * @throws ValidatorConnectionError The validator disconnected.
    */
-  ByteString getResult(long timeout) throws InterruptedException, TimeoutException,
-      ValidatorConnectionError;
+  ByteString getResult(long timeout) throws InterruptedException, TimeoutException, ValidatorConnectionError;
 
-  /** Set the result of the Future.
-   *
+  /**
+   * Set the result of the Future.
    * @param byteString the result.
    * @throws ValidatorConnectionError The validator disconnected.
    */
   void setResult(ByteString byteString) throws ValidatorConnectionError;
 
-  /** The future is available.
-   *
+  /**
+   * The future is available.
    * @return boolean True if the future is resolved, false otherwise.
    * @throws ValidatorConnectionError The validator disconnected.
    */

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/FutureByteString.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/FutureByteString.java
@@ -16,14 +16,13 @@ package sawtooth.sdk.messaging;
 
 import com.google.protobuf.ByteString;
 
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-/** A future that resolves to ByteString.
- *
+/**
+ * A future that resolves to ByteString.
  */
 public class FutureByteString implements Future {
   /**
@@ -48,8 +47,7 @@ public class FutureByteString implements Future {
 
   /**
    * Constructor.
-   * @param id created with Stream.generateId,
-   *                      to match future with it's result
+   * @param id created with Stream.generateId, to match future with it's result
    */
   public FutureByteString(final String id) {
     this.lock = new ReentrantLock();
@@ -79,11 +77,12 @@ public class FutureByteString implements Future {
   }
 
   /**
-   * Returns the ByteString result. If the timeout expires, throws TimeoutException.
+   * Returns the ByteString result. If the timeout expires, throws
+   * TimeoutException.
    * @param timeout time to wait for a result.
    * @return ByteString protobuf
    * @throws InterruptedException an interrupt happens during the method call.
-   * @throws TimeoutException the result is not received before the timeout.
+   * @throws TimeoutException     the result is not received before the timeout.
    */
   public final ByteString getResult(final long timeout) throws InterruptedException, TimeoutException {
     ByteString byteString = null;
@@ -131,8 +130,8 @@ public class FutureByteString implements Future {
     return answer;
   }
 
-  /** Get the value of the coorelation id.
-   *
+  /**
+   * Get the value of the coorelation id.
    * @return String coorelation id.
    */
   public final String getCorrelationId() {

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/FutureError.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/FutureError.java
@@ -21,15 +21,16 @@ import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
 import java.util.concurrent.TimeoutException;
 
 /**
- * FutureError throws a ValidatorConnectionError from all of its methods.
- * Used to resolve a future with an error response.
+ * FutureError throws a ValidatorConnectionError from all of its methods. Used
+ * to resolve a future with an error response.
  */
 public class FutureError implements Future {
 
   /**
    * Constructor.
    */
-  public FutureError() { }
+  public FutureError() {
+  }
 
   /**
    * Always raises ValidatorConnectionError.
@@ -44,7 +45,7 @@ public class FutureError implements Future {
    * Always raises ValidatorConnectionError.
    * @param time The timeout.
    * @throws ValidatorConnectionError Always throws this Exception.
-   * @throws TimeoutException Does not throw this exception.
+   * @throws TimeoutException         Does not throw this exception.
    * @return Does not return.
    */
   public final ByteString getResult(final long time) throws TimeoutException, ValidatorConnectionError {

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
@@ -36,7 +36,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-
 /**
  * An internal messaging implementation used by the Stream class.
  */
@@ -77,15 +76,14 @@ class SendReceiveThread implements Runnable {
    */
   private ZContext context;
 
-  /** Constructor.
-   *
-   * @param address The address to connect to.
-   * @param hashMap The futures to resolve.
+  /**
+   * Constructor.
+   * @param address  The address to connect to.
+   * @param hashMap  The futures to resolve.
    * @param receiver The incoming messages.
    */
-  SendReceiveThread(final String address,
-                           final ConcurrentHashMap<String, Future> hashMap,
-                           final LinkedBlockingQueue<MessageWrapper> receiver) {
+  SendReceiveThread(final String address, final ConcurrentHashMap<String, Future> hashMap,
+      final LinkedBlockingQueue<MessageWrapper> receiver) {
     super();
     this.url = address;
     this.futures = hashMap;
@@ -102,16 +100,16 @@ class SendReceiveThread implements Runnable {
      */
     private Message message;
 
-    /** Constructor.
-     *
+    /**
+     * Constructor.
      * @param msg The protobuf Message.
      */
     MessageWrapper(final Message msg) {
       this.message = msg;
     }
 
-    /** Return the Message associated with this MessageWrapper.
-     *
+    /**
+     * Return the Message associated with this MessageWrapper.
      * @return Message the message.
      */
     public Message getMessage() {
@@ -120,8 +118,8 @@ class SendReceiveThread implements Runnable {
   }
 
   /**
-   * DisconnectThread is run to handle the validator disconnecting on the other side of the ZMQ
-   * connection.
+   * DisconnectThread is run to handle the validator disconnecting on the other
+   * side of the ZMQ connection.
    */
   private class DisconnectThread extends Thread {
 
@@ -131,39 +129,40 @@ class SendReceiveThread implements Runnable {
     private LinkedBlockingQueue<MessageWrapper> receiveQueue;
 
     /**
-     *  Futures to be resolved.
+     * Futures to be resolved.
      */
     private ConcurrentHashMap<String, Future> futures;
 
-    /** Constructor.
-     *
+    /**
+     * Constructor.
      * @param receiver The queue that receives new messages.
-     * @param hashMap The futures that will be resolved.
+     * @param hashMap  The futures that will be resolved.
      */
     DisconnectThread(final LinkedBlockingQueue<MessageWrapper> receiver,
-                     final ConcurrentHashMap<String, Future> hashMap) {
+        final ConcurrentHashMap<String, Future> hashMap) {
       this.receiveQueue = receiveQueue;
       this.futures = futures;
     }
 
-    /** Put a key and associated value in the futures.
-     *
-     * @param key correlation id
+    /**
+     * Put a key and associated value in the futures.
+     * @param key   correlation id
      * @param value the future.
      */
     void putInFutures(final String key, final Future value) {
       this.futures.put(key, value);
     }
 
-    /** Clear the receiveQueue of all messages, in anticipation of sending an error message.
-     *
+    /**
+     * Clear the receiveQueue of all messages, in anticipation of sending an error
+     * message.
      */
     void clearReceiveQueue() {
       this.receiveQueue.clear();
     }
 
-    /** Put a message in the ReceiveQueue.
-     *
+    /**
+     * Put a message in the ReceiveQueue.
      * @param wrapper The message wrapper.
      * @throws InterruptedException An Interrupt happened during the method call.
      */
@@ -171,8 +170,8 @@ class SendReceiveThread implements Runnable {
       this.receiveQueue.put(wrapper);
     }
 
-    /** Return an enumeration of the coorelation ids.
-     *
+    /**
+     * Return an enumeration of the coorelation ids.
      * @return coorelation ids.
      */
     ConcurrentHashMap.KeySetView<String, Future> getFuturesKeySet() {
@@ -196,13 +195,12 @@ class SendReceiveThread implements Runnable {
      */
     private LinkedBlockingQueue<MessageWrapper> receiveQueue;
 
-    /** Constructor.
-     *
-     * @param hashMap The futures that will be resolved.
+    /**
+     * Constructor.
+     * @param hashMap  The futures that will be resolved.
      * @param receiver The new messages that will get added to.
      */
-    Receiver(final ConcurrentHashMap<String, Future> hashMap,
-             final LinkedBlockingQueue<MessageWrapper> receiver) {
+    Receiver(final ConcurrentHashMap<String, Future> hashMap, final LinkedBlockingQueue<MessageWrapper> receiver) {
       this.futures = hashMap;
       this.receiveQueue = receiver;
     }
@@ -259,7 +257,7 @@ class SendReceiveThread implements Runnable {
           if (event.getEvent() == ZMQ.EVENT_DISCONNECTED) {
             try {
               MessageWrapper disconnectMsg = new MessageWrapper(null);
-              for (String key: this.getFuturesKeySet()) {
+              for (String key : this.getFuturesKeySet()) {
                 Future future = new FutureError();
                 this.putInFutures(key, future);
               }
@@ -314,7 +312,5 @@ class SendReceiveThread implements Runnable {
     this.socket.close();
     this.context.destroy();
   }
-
-
 
 }

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
@@ -140,8 +140,8 @@ class SendReceiveThread implements Runnable {
      */
     DisconnectThread(final LinkedBlockingQueue<MessageWrapper> receiver,
         final ConcurrentHashMap<String, Future> hashMap) {
-      this.receiveQueue = receiveQueue;
-      this.futures = futures;
+      this.receiveQueue = SendReceiveThread.this.receiveQueue;
+      this.futures = SendReceiveThread.this.futures;
     }
 
     /**

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/SendReceiveThread.java
@@ -224,7 +224,7 @@ class SendReceiveThread implements Runnable {
         if (this.futures.containsKey(message.getCorrelationId())) {
           Future future = this.futures.get(message.getCorrelationId());
           future.setResult(message.getContent());
-          this.futures.put(message.getCorrelationId(), future);
+          this.futures.remove(message.getCorrelationId(), future);
         } else {
           MessageWrapper wrapper = new MessageWrapper(message);
           this.receiveQueue.put(wrapper);

--- a/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Stream.java
+++ b/sawtooth-sdk-transaction-processor/src/main/java/sawtooth/sdk/messaging/Stream.java
@@ -27,19 +27,23 @@ public interface Stream extends AutoCloseable {
 
   /**
    * Send a message and return a Future that will later have the Bytestring.
-   * @param destination one of the Message.MessageType enum values defined in validator.proto
-   * @param contents the ByteString that has been serialized from a Protobuf class
-   * @return future a future that will have ByteString that can be deserialized into a,
-   *         for example, GetResponse
+   * @param destination one of the Message.MessageType enum values defined in
+   *                    validator.proto
+   * @param contents    the ByteString that has been serialized from a Protobuf
+   *                    class
+   * @return future a future that will have ByteString that can be deserialized
+   *         into a, for example, GetResponse
    */
   Future send(Message.MessageType destination, ByteString contents);
 
   /**
-   * Send a message without getting a future back.
-   * Useful for sending a response message to, for example, a transaction
-   * @param destination Message.MessageType defined in validator.proto
-   * @param correlationId a random string generated on the server for the client to send back
-   * @param contents ByteString serialized contents that the server is expecting
+   * Send a message without getting a future back. Useful for sending a response
+   * message to, for example, a transaction
+   * @param destination   Message.MessageType defined in validator.proto
+   * @param correlationId a random string generated on the server for the client
+   *                      to send back
+   * @param contents      ByteString serialized contents that the server is
+   *                      expecting
    */
   void sendBack(Message.MessageType destination, String correlationId, ByteString contents);
 
@@ -50,7 +54,8 @@ public interface Stream extends AutoCloseable {
   Message receive();
 
   /**
-   * Get a message that has been received. If the timeout is expired, throws TimeoutException.
+   * Get a message that has been received. If the timeout is expired, throws
+   * TimeoutException.
    * @param timeout time to wait for a message.
    * @return result, a protobuf Message
    * @throws TimeoutException The Message is not received before timeout.


### PR DESCRIPTION
This pull resolves the following 

- SendReceiveThread.DisconnectThread constructor assigned two fields improperly, having no useful effect
- SendReceiveThread.handle never removed futures once they had been satisfied, so the futureMap would grow endlessly 
- formatting for sawtooth.sdk.messaging.*