### PR TITLE
Set consensus.algorithm.name and version in tests

### DIFF
--- a/examples/intkey_java/tests/test_intkey_smoke_java.yaml
+++ b/examples/intkey_java/tests/test_intkey_smoke_java.yaml
@@ -54,7 +54,12 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/examples/xo_java/tests/test_xo_smoke_java.yaml
+++ b/examples/xo_java/tests/test_xo_smoke_java.yaml
@@ -54,7 +54,12 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \


### PR DESCRIPTION
This is now a required setting in chime so the tests fail without
this.

Signed-off-by: Richard Berg <rberg@bitwise.io>