### PR TITLE
Pin Coverage to version 5.5

### DIFF
--- a/examples/intkey_java/intkey-tests.dockerfile
+++ b/examples/intkey_java/intkey-tests.dockerfile
@@ -51,7 +51,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN mkdir -p /var/log/sawtooth
 

--- a/examples/xo_java/xo-tests.dockerfile
+++ b/examples/xo_java/xo-tests.dockerfile
@@ -52,7 +52,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN mkdir -p /var/log/sawtooth
 


### PR DESCRIPTION
The 6.0 release of Coverage dropped support for python 3.5, which is the last
supported version on Xenial.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>