### PR TITLE
Remove `coverage` from test Dockerfiles

### DIFF
--- a/examples/intkey_java/intkey-tests.dockerfile
+++ b/examples/intkey_java/intkey-tests.dockerfile
@@ -50,9 +50,6 @@ RUN apt-get install -y -q \
     python3-nose2 \
     python3-pip
 
-RUN pip3 install \
-    coverage --upgrade
-
 RUN mkdir -p /var/log/sawtooth
 
 ENV PATH=$PATH:/project/sawtooth-core/bin

--- a/examples/xo_java/xo-tests.dockerfile
+++ b/examples/xo_java/xo-tests.dockerfile
@@ -51,9 +51,6 @@ RUN apt-get install -y -q \
     python3-nose2 \
     python3-pip
 
-RUN pip3 install \
-    coverage --upgrade
-
 RUN mkdir -p /var/log/sawtooth
 
 ENV PATH=$PATH:/project/sawtooth-core/bin


### PR DESCRIPTION
The 6.0 release of Coverage dropped support for python 3.5, which is the last
supported version on Xenial so it can no longer be installed properly. However,
it's not required to run the tests so it can be removed safely.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>