### PR TITLE
Bump junit from 4.12 to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
       <dependency>
        <groupId>junit</groupId>
        <artifactId>junit</artifactId>
-       <version>4.12</version>
+       <version>4.13.1</version>
        <scope>test</scope>
       </dependency>
       <dependency>

--- a/sawtooth-sdk-signing/pom.xml
+++ b/sawtooth-sdk-signing/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Dependabot suggested this change in
https://github.com/hyperledger/sawtooth-sdk-java/pull/39

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>